### PR TITLE
[feat] #10 메인 작업물 포스트 UI

### DIFF
--- a/src/app/components/common/DetailTag.tsx
+++ b/src/app/components/common/DetailTag.tsx
@@ -1,0 +1,14 @@
+interface DetailTagProps {
+  tag: string;
+}
+
+const DetailTag = ({ tag }: DetailTagProps) => {
+  return (
+    <div className="flex w-32 h-12 pl-3.5 pr-5 py-2.5 bg-zinc-300 rounded-3xl justify-center items-center gap-5">
+      <div className="w-7 h-7 bg-neutral-400 rounded-full"></div>
+      <div className="text-black text-xl">UXUI</div>
+    </div>
+  );
+};
+
+export default DetailTag;

--- a/src/app/components/main/HotPostItem.tsx
+++ b/src/app/components/main/HotPostItem.tsx
@@ -1,0 +1,16 @@
+const HotPostItem = () => {
+  return (
+    <div className="relative cursor-pointer">
+      <div className="w-[683px] h-[300px] bg-zinc-300 rounded-lg text-black "></div>
+      <div className="absolute bottom-[16px] left-[20px]">
+        <p className="text-xl font-semibold ">제목</p>
+        <p className="text-lg font-medium ">소제목</p>
+      </div>
+      <div className="absolute bottom-[22px] right-[30px] flex justify-center items-center w-20 h-8 text-xl font-semibold bg-neutral-400 rounded-2xl">
+        <p>1위</p>
+      </div>
+    </div>
+  );
+};
+
+export default HotPostItem;

--- a/src/app/components/main/PostItem.tsx
+++ b/src/app/components/main/PostItem.tsx
@@ -1,0 +1,22 @@
+const PostItem = () => {
+  return (
+    <div className="relative cursor-pointer">
+      <div className="absolute top-3 right-3 w-8 h-8 bg-zinc-500 rounded-full"></div>
+      <div className=" w-72 h-72 bg-zinc-300 rounded-lg text-sm "></div>
+      <div className="flex justify-between items-center w-full h-[35px] mt-[11px]">
+        <div className="flex justify-center items-center gap-[10px]">
+          <div className="w-8 h-8 bg-zinc-300 rounded-full"></div>
+          <p className="font-semibold"> 본인 이름</p>
+        </div>
+        <div className="flex gap-[10px] justify-center items-center ">
+          <div className="w-5 h-5 bg-zinc-500 rounded-full"></div>
+          <p>122</p>
+          <div className="w-5 h-5 bg-zinc-500 rounded-full"></div>
+          <p>12</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostItem;

--- a/src/app/components/main/containers/HotPostListContainer.tsx
+++ b/src/app/components/main/containers/HotPostListContainer.tsx
@@ -1,0 +1,11 @@
+import HotPostItem from '../HotPostItem';
+
+const HotPostListContainer = () => {
+  return (
+    <div>
+      <HotPostItem />
+    </div>
+  );
+};
+
+export default HotPostListContainer;

--- a/src/app/components/main/containers/PostListContainer.tsx
+++ b/src/app/components/main/containers/PostListContainer.tsx
@@ -1,0 +1,11 @@
+import PostItem from '../PostItem';
+
+const PostListContainer = () => {
+  return (
+    <div>
+      <PostItem />
+    </div>
+  );
+};
+
+export default PostListContainer;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
메인페이지에 표시될 작업물 포스트들의 미리보기 ui를 구현했습니다.
세부 필터가 될 태그 ui를 구현했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
추후 list를 통한 map 함수의 사용이 필요합니다. 
자연스러운 layout을 위해 width와 height를 퍼센트로 변경해야합니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="562" alt="image" src="https://github.com/Leets-Official/WeNeed-FE/assets/70098144/49cf6196-0b0a-444d-a4b0-30b1c414f005">

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
close #9
